### PR TITLE
fix: corrige indentação que quebrava o build do FAQ

### DIFF
--- a/src/components/storyblok/sb-duvidas-frequentes-section.tsx
+++ b/src/components/storyblok/sb-duvidas-frequentes-section.tsx
@@ -48,9 +48,9 @@ export const SbDuvidasFrequentesSection = ({
           <Accordion type="multiple" className="my-8">
             {duvidas.map((d) => (
               <AccordionItem
-              key={d._uid}
-              value={d._uid}
-              className="border-y border-gray-200 hover:bg-app-neutral-50/20"
+                key={d._uid}
+                value={d._uid}
+                className="border-y border-gray-200 hover:bg-app-neutral-50/20"
               >
                 <AccordionTrigger className="flex justify-between w-full p-6">
                   <p className="text-lg font-medium text-left">{d.pergunta}</p>


### PR DESCRIPTION
## Problema

O `main` está com o build quebrado desde o merge do #48. O `next build` (mesmo comando que a Netlify roda) falha:

```
Failed to compile.
./src/components/storyblok/sb-duvidas-frequentes-section.tsx
51:15  Error: Insert `··`  prettier/prettier
52:1   Error: Insert `··`  prettier/prettier
53:1   Error: Insert `··`  prettier/prettier
```

As props `key` / `value` / `className` do `AccordionItem` estão com 2 espaços a menos de indentação.

## Contexto

Esse mesmo erro já tinha entrado no #44, foi revertido no #45, e voltou idêntico no #48 — que foi mergeado mesmo com o deploy preview da Netlify em **failed**.

## Fix

Reindentação das 3 linhas. Nenhuma mudança de comportamento.

## Verificação

`npm run build` passa localmente, gerando as 6 páginas estáticas normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)